### PR TITLE
Add iTerm2 with JetBrains Darcula theme and improve macOS setup

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -2,7 +2,7 @@ export ZSH=~/.oh-my-zsh
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:$path"
 
 export TERM=xterm-256color
-ZSH_THEME="robbyrussell"
+ZSH_THEME="daveverwer"
 
 plugins=(fast-syntax-highlighting)
 

--- a/dotfiles/iterm2/DynamicProfiles/jetbrains-darcula.json
+++ b/dotfiles/iterm2/DynamicProfiles/jetbrains-darcula.json
@@ -1,0 +1,140 @@
+{
+  "Profiles": [
+    {
+      "Name": "JetBrains Darcula",
+      "Guid": "jetbrains-darcula-profile-001",
+      "Default Bookmark": "Yes",
+      "Custom Directory": "Recycle",
+      "Working Directory": "/Users",
+      "Ansi 0 Color": {
+        "Red Component": 0.0,
+        "Green Component": 0.0,
+        "Blue Component": 0.0
+      },
+      "Ansi 1 Color": {
+        "Red Component": 0.98039215803146362,
+        "Green Component": 0.32549020648002625,
+        "Blue Component": 0.3333333432674408
+      },
+      "Ansi 2 Color": {
+        "Red Component": 0.070588238537311554,
+        "Green Component": 0.43137255311012268,
+        "Blue Component": 0.0
+      },
+      "Ansi 3 Color": {
+        "Red Component": 0.7607843279838562,
+        "Green Component": 0.76470589637756348,
+        "Blue Component": 0.0
+      },
+      "Ansi 4 Color": {
+        "Red Component": 0.27058824896812439,
+        "Green Component": 0.5058823823928833,
+        "Blue Component": 0.92156863212585449
+      },
+      "Ansi 5 Color": {
+        "Red Component": 0.98039215803146362,
+        "Green Component": 0.32941177487373352,
+        "Blue Component": 1.0
+      },
+      "Ansi 6 Color": {
+        "Red Component": 0.20000000298023224,
+        "Green Component": 0.7607843279838562,
+        "Blue Component": 0.75686275959014893
+      },
+      "Ansi 7 Color": {
+        "Red Component": 0.67843139171600342,
+        "Green Component": 0.67843139171600342,
+        "Blue Component": 0.67843139171600342
+      },
+      "Ansi 8 Color": {
+        "Red Component": 0.33333333333333331,
+        "Green Component": 0.33333333333333331,
+        "Blue Component": 0.33333333333333331
+      },
+      "Ansi 9 Color": {
+        "Red Component": 0.9843137264251709,
+        "Green Component": 0.44313725829124451,
+        "Blue Component": 0.44705882668495178
+      },
+      "Ansi 10 Color": {
+        "Red Component": 0.40392157435417175,
+        "Green Component": 1.0,
+        "Blue Component": 0.30980393290519714
+      },
+      "Ansi 11 Color": {
+        "Red Component": 1.0,
+        "Green Component": 1.0,
+        "Blue Component": 0.0
+      },
+      "Ansi 12 Color": {
+        "Red Component": 0.42745098471641541,
+        "Green Component": 0.61568629741668701,
+        "Blue Component": 0.94509804248809814
+      },
+      "Ansi 13 Color": {
+        "Red Component": 0.9843137264251709,
+        "Green Component": 0.50980395078659058,
+        "Blue Component": 1.0
+      },
+      "Ansi 14 Color": {
+        "Red Component": 0.37647059559822083,
+        "Green Component": 0.82745099067687988,
+        "Blue Component": 0.81960785388946533
+      },
+      "Ansi 15 Color": {
+        "Red Component": 0.93333333730697632,
+        "Green Component": 0.93333333730697632,
+        "Blue Component": 0.93333333730697632
+      },
+      "Background Color": {
+        "Red Component": 0.12549020349979401,
+        "Green Component": 0.12549020349979401,
+        "Blue Component": 0.12549020349979401
+      },
+      "Foreground Color": {
+        "Red Component": 0.67843139171600342,
+        "Green Component": 0.67843139171600342,
+        "Blue Component": 0.67843139171600342
+      },
+      "Bold Color": {
+        "Red Component": 0.93333333730697632,
+        "Green Component": 0.93333333730697632,
+        "Blue Component": 0.93333333730697632
+      },
+      "Cursor Color": {
+        "Red Component": 1.0,
+        "Green Component": 1.0,
+        "Blue Component": 1.0
+      },
+      "Cursor Text Color": {
+        "Red Component": 0.0,
+        "Green Component": 0.0,
+        "Blue Component": 0.0
+      },
+      "Selection Color": {
+        "Red Component": 0.10196078568696976,
+        "Green Component": 0.19607843458652496,
+        "Blue Component": 0.44705882668495178
+      },
+      "Selected Text Color": {
+        "Red Component": 0.67843139171600342,
+        "Green Component": 0.67843139171600342,
+        "Blue Component": 0.67843139171600342
+      },
+      "Normal Font": "MesloLGS-NF-Regular 13",
+      "Non Ascii Font": "MesloLGS-NF-Regular 13",
+      "Horizontal Spacing": 1.0,
+      "Vertical Spacing": 1.1,
+      "Use Bold Font": true,
+      "Use Bright Bold": true,
+      "Use Italic Font": true,
+      "ASCII Anti Aliased": true,
+      "Non-ASCII Anti Aliased": true,
+      "Scrollback Lines": 10000,
+      "Unlimited Scrollback": false,
+      "Transparency": 0.0,
+      "Blur": false
+    }
+  ]
+}
+

--- a/machine-fresh-install.sh
+++ b/machine-fresh-install.sh
@@ -123,17 +123,11 @@ create_resources() {
     "$HOME/projects"
   )
 
-  if [ -d "$HOME/.vim" ]; then
-    sudo chown -R "$user:$user_group" "$HOME/.vim"
-  fi
-
   for dirname in "${DIRS[@]}"; do
     mkdir -p "$dirname"
-    sudo chown -R "$user:$user_group" "$dirname"
   done
 
   touch "$HOME/.private_work_aliases"
-  sudo chown "$user:$user_group" "$HOME/.private_work_aliases"
 
   chmod -R u+rwX ~/.vim/undo ~/.vim/swap
 
@@ -148,7 +142,21 @@ prepare_dotfiles() {
     exit 1
   fi
 
-  cp -r "$dotfiles_dir"/. "$HOME"/
+  # Copy standard dotfiles to home
+  for item in "$dotfiles_dir"/.*; do
+    [ -e "$item" ] || continue
+    basename=$(basename "$item")
+    [ "$basename" = "." ] || [ "$basename" = ".." ] && continue
+    cp -r "$item" "$HOME/"
+  done
+
+  # Copy iTerm2 dynamic profiles on macOS
+  if [ "$os_type" = "macos" ] && [ -d "$dotfiles_dir/iterm2/DynamicProfiles" ]; then
+    local iterm_profiles_dir="$HOME/Library/Application Support/iTerm2/DynamicProfiles"
+    mkdir -p "$iterm_profiles_dir"
+    cp -r "$dotfiles_dir/iterm2/DynamicProfiles/"* "$iterm_profiles_dir/"
+    echo "iTerm2 profile installed"
+  fi
 
   echo "Dotfiles added"
 }
@@ -174,6 +182,17 @@ install_programs_ubuntu() {
   apt_install_if_missing wget
 }
 
+brew_cask_install_if_missing() {
+  local cask=$1
+  ensure_brew
+  if brew list --cask --versions "$cask" >/dev/null 2>&1; then
+    echo "$cask already installed"
+    return
+  fi
+
+  brew install --cask "$cask"
+}
+
 install_programs_macos() {
   brew_install_if_missing tmux
   brew_install_if_missing the_silver_searcher
@@ -182,6 +201,7 @@ install_programs_macos() {
   brew_install_if_missing zsh
   brew_install_if_missing vim
   brew_install_if_missing wget
+  brew_cask_install_if_missing iterm2
 }
 
 install_fonts() {
@@ -237,9 +257,9 @@ plugins_setup() {
   # Vundle plugin manager for vim
   local vundle_dir="$HOME/.vim/bundle/Vundle.vim"
   if [ -d "$vundle_dir/.git" ]; then
-    sudo git -C "$vundle_dir" pull --ff-only
+    git -C "$vundle_dir" pull --ff-only
   else
-    sudo git clone https://github.com/VundleVim/Vundle.vim.git "$vundle_dir"
+    git clone https://github.com/VundleVim/Vundle.vim.git "$vundle_dir"
   fi
 
   # Tmux plugins
@@ -252,7 +272,7 @@ plugins_setup() {
   chmod -R 777 ~/.tmux
 
   # Vim plugins
-  sudo vim +PluginInstall +qall
+  vim +PluginInstall +qall
 }
 
 

--- a/readme.md
+++ b/readme.md
@@ -4,14 +4,32 @@ Usage:
 ```
 ./machine-fresh-install.sh
 ```
-After set-up is complete:
-- Set ZSH as default shell
-  - Terminal -> Preference -> New Profile -> Command and use `/usr/bin/zsh`
-- Fix Mac Ventura tmux prefix override
-  - Settings > Customise modifier keys > Input sources > uncheck anything using `^Space`
-- Install Tmux plugins by doing `Prefix (Ctl + Space) + I`
-- Install Vim Plugins with `PluginInstall`
 
-Notes:
+## After Setup
+
+### Both Platforms
+- Install Tmux plugins: `Prefix (Ctrl + Space) + I`
+- Install Vim plugins: `:PluginInstall`
+
+### Ubuntu
+- Set ZSH as default shell:
+  - Terminal → Preferences → New Profile → Command → use `/usr/bin/zsh`
+
+### macOS
+- **Use iTerm2** (installed by the script):
+  - Open iTerm2 and go to **iTerm2 → Settings → Profiles**
+  - Select "**JetBrains Darcula**" from the list (automatically installed)
+  - Click **Other Actions... → Set as Default**
+- **Fix Ctrl+Space conflict with tmux prefix:**
+  - macOS uses Ctrl+Space for input source switching (you'll see an "A" icon toggling)
+  - Go to **System Settings → Keyboard → Keyboard Shortcuts... → Input Sources**
+  - Uncheck "Select the previous input source" and "Select next source in input menu"
+  - This allows Ctrl+Space to pass through to tmux
+- **Grant clipboard access to iTerm2:**
+  - Go to **System Settings → Privacy & Security → Accessibility**
+  - Add and enable iTerm2
+  - This allows tmux-yank and other tools to access the system clipboard
+
+## Notes
 - On Ubuntu the script uses `apt` to install prerequisites.
 - On macOS the script relies on Homebrew (it will be installed automatically if missing).


### PR DESCRIPTION
- Remove unnecessary sudo calls from script (no sudo needed for home dir)
- Add iTerm2 installation via brew cask on macOS
- Add JetBrains Darcula color scheme as Dynamic Profile
- Update prepare_dotfiles to copy iTerm2 profiles to correct location
- Change zsh theme to daveverwer
- Update readme with separate Ubuntu/macOS sections
- Add instructions for fixing Ctrl+Space conflict with tmux prefix
- Add clipboard access instructions for iTerm2